### PR TITLE
Fix build in gcc 13

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -9,6 +9,7 @@
 #include "args.h"
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include <iostream>
 #include <stdexcept>


### PR DESCRIPTION
Ran into this while trying to use the fasttext crate.

https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes